### PR TITLE
Add Entity–Relationship Model to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This project was developed with the following technologies:
 3.  run  `bundle exec rails db:seeds`
 
 ### Unit Testing
-You have to run the following command in a terminal: `bundle exec rspe`
+You have to run the following command in a terminal: `bundle exec rspec`
 
 ### Code Formatter
 To improve the quality of the source code, the following gems have been added to the project.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ This endpoint returns the current amount of the user.
     "balance": 100.0
 }
 ```
+## Entity–Relationship Model
+The following graphic represents the models involved in the business logic built for the APIs described above.
+![Entity–Relationship Model](https://github.com/szcrubyroostrap/venmo-api/blob/development/public/Api-ER.png?raw=true)
 
 ## Setup instructions
 
@@ -99,7 +102,7 @@ This project was developed with the following technologies:
 3.  run  `bundle exec rails db:seeds`
 
 ### Unit Testing
-You have to run the following command in a terminal: `bundle exec rspec`
+You have to run the following command in a terminal: `bundle exec rspe`
 
 ### Code Formatter
 To improve the quality of the source code, the following gems have been added to the project.


### PR DESCRIPTION
**Feature**

**Feature identification:** Add Entity-Relationship to Readme.

**Description:**
- Adding file to `/public` folder to be loaded in Readme.
- Correction in Readme due to symbol added by mistake.

**Notes**
The image was added using the development branch URL to be accessible by the Readme.