### PR TITLE
adding postman example for postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ This project was developed with the following technologies:
 ### Unit Testing
 You have to run the following command in a terminal: `bundle exec rspec`
 
+### Manual Testing
+In the `/ public` folder there is the` venmo-api.postman_collection.json` file with a set of tests performed from Postman to the endpoints described in the API.
+
 ### Code Formatter
 To improve the quality of the source code, the following gems have been added to the project.
 1.  `Annotate`  (Adds comments to the models and factories taking into account the current database schema)

--- a/public/venmo-api.postman_collection.json
+++ b/public/venmo-api.postman_collection.json
@@ -1,0 +1,99 @@
+{
+	"info": {
+		"_postman_id": "5f59cee4-491e-4fc2-9d8c-8af3f9a2ef10",
+		"name": "venmo-api",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Make a Payment",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"friend_id\": 2,\n    \"amount\": 100,\n    \"description\": \"payment test\"\n}\n"
+				},
+				"url": {
+					"raw": "localhost:3000/user/1/payment",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"user",
+						"1",
+						"payment"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "User Balance",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text",
+						"disabled": true
+					}
+				],
+				"url": {
+					"raw": "localhost:3000/user/1/balance",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"user",
+						"1",
+						"balance"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Feed",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"page\": 1\n}\n"
+				},
+				"url": {
+					"raw": "localhost:3000/user/1/feed",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"user",
+						"1",
+						"feed"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
Feature

**Feature identification:** Add Json examples from Postman

**Description:**

- `venmo-api.postman_collection.json` added in `/public` folder.
- Readme was updated due to json example available in `/public`.